### PR TITLE
Bug/sample dependencies

### DIFF
--- a/MobileBuy/sample/build.gradle.packaging
+++ b/MobileBuy/sample/build.gradle.packaging
@@ -74,6 +74,7 @@ dependencies {
     compile 'com.android.support:support-v4:23.0.1'
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.android.support:palette-v7:23.0.1'
+    compile 'com.android.support:customtabs:23.0.1'
 
     compile (name:'buy-1.2.1', ext:'aar')
 }

--- a/MobileBuy/sample/src/main/AndroidManifest.xml
+++ b/MobileBuy/sample/src/main/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     package="com.shopify.sample"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-sdk tools:overrideLibrary="android.support.customtabs"/>
 
     <application
         android:name=".application.SampleApplication"


### PR DESCRIPTION
There were a couple of dependencies missing on the sample application to allow it to build and run for API level 14 and co-exist happily with Chrome Custom Tabs.

@dave-pelletier  please review.