### PR TITLE
Remove shippingRateId from Checkout

### DIFF
--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Checkout.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Checkout.java
@@ -119,9 +119,6 @@ public class Checkout extends ShopifyObject {
     @SerializedName("shipping_rate")
     private ShippingRate shippingRate;
 
-    @SerializedName("shipping_rate_id")
-    private String shippingRateId;
-
     @SerializedName("marketing_attribution")
     private MarketingAttribution marketingAttribution;
 


### PR DESCRIPTION
Shipping Rate Id is not required on the Checkout.

@dave-pelletier please review