### PR TITLE
Change the visibility of  the general id field

### DIFF
--- a/MobileBuy/buy/src/androidTest/java/com/shopify/buy/extensions/CheckoutPrivateAPIs.java
+++ b/MobileBuy/buy/src/androidTest/java/com/shopify/buy/extensions/CheckoutPrivateAPIs.java
@@ -18,6 +18,11 @@ public class CheckoutPrivateAPIs extends Checkout {
         super(cart);
     }
 
+    @Override
+    public Long getId() {
+        return super.getId();
+    }
+
     public static CheckoutPrivateAPIs fromCheckout(Checkout checkout) {
         Gson gson = BuyClientUtils.createDefaultGson();
         String checkoutJson = gson.toJson(checkout);

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Address.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Address.java
@@ -60,6 +60,11 @@ public class Address extends ShopifyObject {
 
     private String zip;
 
+    @Override
+    public Long getId() {
+        return super.getId();
+    }
+
     /**
      * @return The unique identifier of this object within the Shopify platform.
      */

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Checkout.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Checkout.java
@@ -177,6 +177,11 @@ public class Checkout extends ShopifyObject {
         lineItems.add(lineItem);
     }
 
+    @Override
+    public Long getId() {
+        return super.getId();
+    }
+
     public void setLineItems(Cart cart) {
         this.lineItems.clear();
         this.lineItems.addAll(cart.getLineItems());

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Collection.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Collection.java
@@ -166,4 +166,19 @@ public class Collection extends ShopifyObject {
         return BuyClientUtils.createDefaultGson().fromJson(json, Collection.class);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Collection)) return false;
+
+        Collection that = (Collection) o;
+
+        return collectionId.equals(that.collectionId);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return collectionId.hashCode();
+    }
 }

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Customer.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Customer.java
@@ -92,6 +92,11 @@ public class Customer extends ShopifyObject {
     @SerializedName("default_address")
     private Address defaultAddress;
 
+    @Override
+    public Long getId() {
+        return super.getId();
+    }
+
     /**
      * @return The email for this customer.
      */

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Image.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Image.java
@@ -51,6 +51,11 @@ public class Image extends ShopifyObject {
 
     protected String src;
 
+    @Override
+    public Long getId() {
+        return super.getId();
+    }
+
     /**
      * @return Creation date of the image.
      */

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Option.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Option.java
@@ -38,6 +38,11 @@ public class Option extends ShopifyObject {
     @SerializedName("product_id")
     protected String productId;
 
+    @Override
+    public Long getId() {
+        return super.getId();
+    }
+
     /**
      * @return The unique identifier for the {@link Product} associated with this option.
      */

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Order.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Order.java
@@ -76,6 +76,11 @@ public class Order extends ShopifyObject {
     public Order() {
     }
 
+    @Override
+    public Long getId() {
+        return super.getId();
+    }
+
     /**
      * @return URL for the website showing the order status.  This url will pass an authentication token for the currently logged in user. This is only available for Orders returned using {@link com.shopify.buy.dataprovider.BuyClient#getOrder(Customer, String, Callback)} or {@link com.shopify.buy.dataprovider.BuyClient#getOrders(Customer, Callback)}
      */

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Product.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Product.java
@@ -345,6 +345,22 @@ public class Product extends ShopifyObject {
         return minimumPrice;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Product)) return false;
+
+        Product product = (Product) o;
+
+        return productId.equals(product.productId);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return productId.hashCode();
+    }
+
     public static class ProductDeserializer implements JsonDeserializer<Product> {
 
         @Override

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/ProductVariant.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/ProductVariant.java
@@ -74,6 +74,11 @@ public class ProductVariant extends ShopifyObject {
     @SerializedName("image_url")
     protected String imageUrl;
 
+    @Override
+    public Long getId() {
+        return super.getId();
+    }
+
     /**
      * @return The title of this variant.
      */

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Shop.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Shop.java
@@ -66,6 +66,11 @@ public class Shop extends ShopifyObject {
     @SerializedName("published_products_count")
     protected long publishedProductsCount;
 
+    @Override
+    public Long getId() {
+        return super.getId();
+    }
+
     /**
      * @return The name of this shop.
      */

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/ShopifyObject.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/ShopifyObject.java
@@ -36,7 +36,7 @@ public abstract class ShopifyObject {
     /**
      * @return The unique identifier of this object within the Shopify platform.
      */
-    public Long getId() {
+    protected Long getId() {
         return id;
     }
 


### PR DESCRIPTION
Change the visibility of  the general id field and expose it as public only for those classes that supports it.
Change equals/hashcode for Collection/Product object to use the collectionId/productId instead general id field.

@yervantk @krisorr 