### PR TITLE
use the CustomerId as a parameter for the renew customer api

### DIFF
--- a/MobileBuy/buy/src/androidTest/java/com/shopify/buy/service/BuyClientFacadeTest.java
+++ b/MobileBuy/buy/src/androidTest/java/com/shopify/buy/service/BuyClientFacadeTest.java
@@ -73,7 +73,7 @@ public class BuyClientFacadeTest extends ShopifyAndroidTestCase {
             }
         }));
         Assert.assertNotNull(buyClient.getCustomer(1L));
-        Assert.assertNotNull(buyClient.renewCustomer());
+        Assert.assertNotNull(buyClient.renewCustomer(1L));
         Assert.assertNotNull(buyClient.recoverPassword("test"));
         Assert.assertNotNull(buyClient.getOrders(1L));
         Assert.assertNotNull(buyClient.getOrder(1L, 1L));

--- a/MobileBuy/buy/src/androidTest/java/com/shopify/buy/service/CustomerTest.java
+++ b/MobileBuy/buy/src/androidTest/java/com/shopify/buy/service/CustomerTest.java
@@ -183,7 +183,7 @@ public class CustomerTest extends ShopifyAndroidTestCase {
 
         final CountDownLatch latch = new CountDownLatch(1);
 
-        buyClient.renewCustomer(new Callback<CustomerToken>() {
+        buyClient.renewCustomer(customer.getId(), new Callback<CustomerToken>() {
             @Override
             public void success(CustomerToken customerToken) {
                 latch.countDown();

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/BuyClientDefault.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/BuyClientDefault.java
@@ -355,13 +355,13 @@ final class BuyClientDefault implements BuyClient {
     }
 
     @Override
-    public CancellableTask renewCustomer(Callback<CustomerToken> callback) {
-        return customerService.renewCustomer(callback);
+    public CancellableTask renewCustomer(Long customerId, Callback<CustomerToken> callback) {
+        return customerService.renewCustomer(customerId, callback);
     }
 
     @Override
-    public Observable<CustomerToken> renewCustomer() {
-        return customerService.renewCustomer();
+    public Observable<CustomerToken> renewCustomer(Long customerId) {
+        return customerService.renewCustomer(customerId);
     }
 
     @Override

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/CustomerService.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/CustomerService.java
@@ -170,16 +170,18 @@ public interface CustomerService {
      * Renew a Customer login.  This should be called periodically to keep the token up to date.
      *
      * @param callback the {@link Callback} that will be used to indicate the response from the asynchronous network operation, not null
+     * @param customerId the identifier of a {@link CustomerToken} or {@link Customer}, not null
      * @return cancelable task
      */
-    CancellableTask renewCustomer(Callback<CustomerToken> callback);
+    CancellableTask renewCustomer(Long customerId, Callback<CustomerToken> callback);
 
     /**
      * Renew a Customer login.  This should be called periodically to keep the token up to date.
      *
+     * @param customerId the identifier of a {@link CustomerToken} or {@link Customer}, not null
      * @return cold observable that emits renewed customer token
      */
-    Observable<CustomerToken> renewCustomer();
+    Observable<CustomerToken> renewCustomer(Long customerId);
 
     /**
      * Send a password recovery email. An email will be sent to the email address specified if a customer with that email address exists on Shopify.

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/CustomerServiceDefault.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/CustomerServiceDefault.java
@@ -267,19 +267,18 @@ final class CustomerServiceDefault implements CustomerService {
     }
 
     @Override
-    public CancellableTask renewCustomer(final Callback<CustomerToken> callback) {
-        return new CancellableTaskSubscriptionWrapper(renewCustomer().subscribe(new InternalCallbackSubscriber<>(callback)));
+    public CancellableTask renewCustomer(Long customerId, final Callback<CustomerToken> callback) {
+        return new CancellableTaskSubscriptionWrapper(renewCustomer(customerId).subscribe(new InternalCallbackSubscriber<>(callback)));
     }
 
     @Override
-    public Observable<CustomerToken> renewCustomer() {
-        final CustomerToken customerToken = customerTokenRef.get();
-        if (customerToken == null) {
-            return Observable.just(null);
+    public Observable<CustomerToken> renewCustomer(Long customerId) {
+        if (customerId == null) {
+            throw new NullPointerException("customer Id cannot be null");
         }
 
         return retrofitService
-            .renewCustomerToken(EMPTY_BODY, customerToken.getCustomerId())
+            .renewCustomerToken(EMPTY_BODY, customerId)
             .doOnNext(new RetrofitSuccessHttpStatusCodeHandler<>())
             .compose(new UnwrapRetrofitBodyTransformer<CustomerTokenWrapper, CustomerToken>())
             .onErrorResumeNext(new BuyClientExceptionHandler<CustomerToken>())


### PR DESCRIPTION
Update our renewCustomer api to take the Customer Id as a parameter.
This matches iOS and makes is easier to renew tokens.

Closes #207 

@yervantk @sav007 please review.