### PR TITLE
make usage of Boolean consistent in the APIs

### DIFF
--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Checkout.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Checkout.java
@@ -249,6 +249,15 @@ public class Checkout extends ShopifyObject {
     }
 
     /**
+     * @deprecated Use {@link #getOrder()}.
+     *
+     * @return The order status.
+     */
+    public String getOrderStatusUrl() {
+        return orderStatusUrl;
+    }
+
+    /**
      * @return The customer's email address.
      */
     public String getEmail() {
@@ -260,6 +269,15 @@ public class Checkout extends ShopifyObject {
      */
     public String getToken() {
         return token;
+    }
+
+    /**
+     * @deprecated Use {@link #getOrder()}.
+     *
+     * @return The order id.
+     */
+    public Long getOrderId() {
+        return orderId;
     }
 
     /**

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Checkout.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Checkout.java
@@ -249,15 +249,6 @@ public class Checkout extends ShopifyObject {
     }
 
     /**
-     * @deprecated Use {@link #getOrder()}.
-     *
-     * @return The order status.
-     */
-    public String getOrderStatusUrl() {
-        return orderStatusUrl;
-    }
-
-    /**
      * @return The customer's email address.
      */
     public String getEmail() {
@@ -269,15 +260,6 @@ public class Checkout extends ShopifyObject {
      */
     public String getToken() {
         return token;
-    }
-
-    /**
-     * @deprecated Use {@link #getOrder()}.
-     *
-     * @return The order id.
-     */
-    public Long getOrderId() {
-        return orderId;
     }
 
     /**
@@ -297,15 +279,15 @@ public class Checkout extends ShopifyObject {
     /**
      * @return {@code true} if the fulfillment of this checkout requires shipping, {@code false} otherwise.
      */
-    public Boolean isRequiresShipping() {
-        return requiresShipping;
+    public boolean isRequiresShipping() {
+        return requiresShipping != null && requiresShipping;
     }
 
     /**
      * @return {@code true} if taxes are included in the price, {@code false} otherwise.
      */
-    public Boolean isTaxesIncluded() {
-        return taxesIncluded;
+    public boolean isTaxesIncluded() {
+        return taxesIncluded != null && taxesIncluded;
     }
 
     /**
@@ -593,8 +575,7 @@ public class Checkout extends ShopifyObject {
      * @return A checkout suitable for sending in an update.
      */
     public Checkout copy() {
-        Checkout copy = Checkout.fromJson(this.toJsonString());
-        return copy;
+        return Checkout.fromJson(this.toJsonString());
     }
 
     /**

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Collection.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Collection.java
@@ -26,7 +26,6 @@ package com.shopify.buy.model;
 
 import com.google.gson.annotations.SerializedName;
 import com.shopify.buy.dataprovider.BuyClientUtils;
-import com.shopify.buy.dataprovider.Callback;
 import com.shopify.buy.model.internal.CollectionImage;
 
 import java.util.Date;
@@ -64,7 +63,7 @@ public class Collection extends ShopifyObject {
 
     protected String handle;
 
-    protected boolean published;
+    protected Boolean published;
 
     @SerializedName("collection_id")
     protected Long collectionId;
@@ -150,7 +149,7 @@ public class Collection extends ShopifyObject {
      * @return {@code true} if this collection has been published on the shop, {@code false} otherwise.
      */
     public boolean isPublished() {
-        return published;
+        return published != null && published;
     }
 
     /**

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Customer.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Customer.java
@@ -108,7 +108,7 @@ public class Customer extends ShopifyObject {
      * @return {code true} if this customer accepts marketing.
      */
     public boolean acceptsMarketing() {
-        return acceptsMarketing;
+        return acceptsMarketing != null && acceptsMarketing;
     }
 
     /**
@@ -171,7 +171,7 @@ public class Customer extends ShopifyObject {
      * @return {code true} if the customer email address has been verified.
      */
     public boolean isVerifiedEmail() {
-        return verifiedEmail;
+        return verifiedEmail != null && verifiedEmail;
     }
 
     /**
@@ -185,7 +185,7 @@ public class Customer extends ShopifyObject {
      * @return Indicates whether the customer should be charged taxes when placing orders. Valid values are {@code true} and {@code false}.
      **/
     public boolean isTaxExempt() {
-        return taxExempt;
+        return taxExempt != null && taxExempt;
     }
 
     /**

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Discount.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Discount.java
@@ -33,13 +33,13 @@ public class Discount {
 
     private String amount;
 
-    private boolean applicable;
+    private Boolean applicable;
 
     private String code;
 
     public Discount() {}
 
-    public Discount(String code) {
+    public Discount(final String code) {
         this.code = code;
     }
 
@@ -54,7 +54,7 @@ public class Discount {
      * @return {@code true} if this discount applies to the checkout, {@code false} otherwise.
      */
     public boolean isApplicable() {
-        return applicable;
+        return applicable != null && applicable;
     }
 
     /**

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/LineItem.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/LineItem.java
@@ -43,7 +43,7 @@ public class LineItem {
     protected String price;
 
     @SerializedName("requires_shipping")
-    protected boolean requiresShipping;
+    protected Boolean requiresShipping;
 
     @SerializedName("variant_id")
     protected Long variantId;
@@ -64,7 +64,7 @@ public class LineItem {
 
     protected String sku;
 
-    protected boolean taxable;
+    protected Boolean taxable;
 
     protected long grams;
 
@@ -126,7 +126,7 @@ public class LineItem {
      * @return {@code true} if this line item is taxable, {@code false} otherwise.
      */
     public boolean isTaxable() {
-        return taxable;
+        return taxable != null && taxable;
     }
 
     /**
@@ -206,7 +206,7 @@ public class LineItem {
      * @return {@code true} if the product that is being purchased in this line item requires shipping, {@code false} otherwise.
      */
     public boolean isRequiresShipping() {
-        return requiresShipping;
+        return requiresShipping != null && requiresShipping;
     }
 
     @Override

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Order.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Order.java
@@ -134,7 +134,7 @@ public class Order extends ShopifyObject {
      * @return true if the Order was cancelled.
      */
     public Boolean isCancelled() {
-        return cancelled;
+        return cancelled != null && cancelled;
     }
 
     /**

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/Product.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/Product.java
@@ -81,9 +81,9 @@ public class Product extends ShopifyObject {
 
     protected Set<String> tagSet;
 
-    protected boolean available;
+    protected Boolean available;
 
-    protected boolean published;
+    protected Boolean published;
 
     private Set<String> prices;
 
@@ -93,7 +93,7 @@ public class Product extends ShopifyObject {
      * @return {@code true} if this product has been published on the store, {@code false} otherwise.
      */
     public boolean isPublished() {
-        return published;
+        return published != null && published;
     }
 
     /**
@@ -241,7 +241,7 @@ public class Product extends ShopifyObject {
      * @return {@code true} if this product is in stock and available for purchase, {@code false} otherwise.
      */
     public boolean isAvailable() {
-        return available;
+        return available != null && available;
     }
 
     /**

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/ProductVariant.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/ProductVariant.java
@@ -50,9 +50,9 @@ public class ProductVariant extends ShopifyObject {
     protected String sku;
 
     @SerializedName("requires_shipping")
-    protected boolean requiresShipping;
+    protected Boolean requiresShipping;
 
-    protected boolean taxable;
+    protected Boolean taxable;
 
     protected int position;
 
@@ -64,7 +64,7 @@ public class ProductVariant extends ShopifyObject {
     @SerializedName("updated_at")
     protected Date updatedAtDate;
 
-    protected boolean available;
+    protected Boolean available;
 
     // NOTE: productTitle and imageUrl are not in the JSON from the server, they are set manually during the Product parsing
 
@@ -125,14 +125,14 @@ public class ProductVariant extends ShopifyObject {
      * @return {@code true} if this variant requires shipping, {@code false} otherwise.
      */
     public boolean isRequiresShipping() {
-        return requiresShipping;
+        return requiresShipping != null && requiresShipping;
     }
 
     /**
      * @return {@code true} if this variant is taxable, {@code false} otherwise.
      */
     public boolean isTaxable() {
-        return taxable;
+        return taxable != null && taxable;
     }
 
     /**
@@ -187,7 +187,7 @@ public class ProductVariant extends ShopifyObject {
      * @return {@code true} if this variant is in stock and available for purchase, {@code false} otherwise.
      */
     public boolean isAvailable() {
-        return available;
+        return available != null && isAvailable();
     }
 
     /**


### PR DESCRIPTION
Make usage of Boolean/boolean consistent in our api.

All Properties are Boolean.
All getters and setters use boolean.
Getters default to false if Boolean property is null.

Closes #239 

@sav007 @bgulanowski please review.


