### PR TITLE
return an error instead of throwing exception if customer token is not set

### DIFF
--- a/MobileBuy/buy/src/androidTest/java/com/shopify/buy/service/IllegalArgumentTest.java
+++ b/MobileBuy/buy/src/androidTest/java/com/shopify/buy/service/IllegalArgumentTest.java
@@ -42,6 +42,8 @@ import org.junit.runner.RunWith;
 import java.util.ArrayList;
 import java.util.Set;
 
+import rx.Subscriber;
+
 @RunWith(AndroidJUnit4.class)
 public class IllegalArgumentTest extends ShopifyAndroidTestCase {
 
@@ -402,33 +404,13 @@ public class IllegalArgumentTest extends ShopifyAndroidTestCase {
         // now clear the token
         buyClient.setCustomerToken(null);
 
-        checkException(IllegalStateException.class, new Runnable() {
-            @Override
-            public void run() {
-                buyClient.updateCustomer(new Customer());
-            }
-        });
+        buyClient.updateCustomer(new Customer()).subscribe(illegalStateSubscriber);
 
-        checkException(IllegalStateException.class, new Runnable() {
-            @Override
-            public void run() {
-                buyClient.logoutCustomer();
-            }
-        });
+        buyClient.logoutCustomer().subscribe(illegalStateSubscriber);
 
-        checkException(IllegalStateException.class, new Runnable() {
-            @Override
-            public void run() {
-                buyClient.getCustomer();
-            }
-        });
+        buyClient.getCustomer().subscribe(illegalStateSubscriber);
 
-        checkException(IllegalStateException.class, new Runnable() {
-            @Override
-            public void run() {
-                buyClient.renewCustomer();
-            }
-        });
+        buyClient.renewCustomer().subscribe(illegalStateSubscriber);
     }
 
     @Test
@@ -445,19 +427,9 @@ public class IllegalArgumentTest extends ShopifyAndroidTestCase {
         // now clear the token
         buyClient.setCustomerToken(null);
 
-        checkException(IllegalStateException.class, new Runnable() {
-            @Override
-            public void run() {
-                buyClient.getOrders();
-            }
-        });
+        buyClient.getOrders().subscribe(illegalStateSubscriber);
 
-        checkException(IllegalStateException.class, new Runnable() {
-            @Override
-            public void run() {
-                buyClient.getOrder(1L);
-            }
-        });
+        buyClient.getOrder(1L).subscribe(illegalStateSubscriber);
     }
 
     @Test
@@ -502,42 +474,34 @@ public class IllegalArgumentTest extends ShopifyAndroidTestCase {
         // now clear the token
         buyClient.setCustomerToken(null);
 
-        checkException(IllegalStateException.class, new Runnable() {
-            @Override
-            public void run() {
-                buyClient.createAddress(new Address());
-            }
-        });
+        buyClient.createAddress(new Address()).subscribe(illegalStateSubscriber);
 
-        checkException(IllegalStateException.class, new Runnable() {
-            @Override
-            public void run() {
-                buyClient.deleteAddress(1L);
-            }
-        });
+        buyClient.deleteAddress(1L).subscribe(illegalStateSubscriber);
 
-        checkException(IllegalStateException.class, new Runnable() {
-            @Override
-            public void run() {
-                buyClient.getAddresses();
-            }
-        });
+        buyClient.getAddresses().subscribe(illegalStateSubscriber);
 
-        checkException(IllegalStateException.class, new Runnable() {
-            @Override
-            public void run() {
-                buyClient.getAddress(1L);
-            }
-        });
+        buyClient.getAddress(1L).subscribe(illegalStateSubscriber);
 
-        checkException(IllegalStateException.class, new Runnable() {
-            @Override
-            public void run() {
-                buyClient.updateAddress(new Address());
-            }
-        });
+        buyClient.updateAddress(new Address()).subscribe(illegalStateSubscriber);
 
     }
+
+    private Subscriber illegalStateSubscriber = new Subscriber() {
+        @Override
+        public void onCompleted() {
+
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            Assert.assertEquals(IllegalStateException.class, e.getCause().getClass());
+        }
+
+        @Override
+        public void onNext(Object o) {
+            Assert.fail("Expected exception");
+        }
+    };
 
     private static void checkException(final Class exceptionClazz, final Runnable call) {
         try {

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/AddressServiceDefault.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/AddressServiceDefault.java
@@ -70,14 +70,14 @@ final class AddressServiceDefault implements AddressService {
 
     @Override
     public Observable<Address> createAddress(final Address address) {
+        if (address == null) {
+            throw new NullPointerException("address cannot be null");
+        }
+
         CustomerToken customerToken = customerService.getCustomerToken();
 
         if (customerToken == null) {
-            throw new IllegalStateException("customer must be logged in");
-        }
-
-        if (address == null) {
-            throw new NullPointerException("address cannot be null");
+            return Observable.error(new BuyClientError(new IllegalStateException("customer must be logged in")));
         }
 
         return retrofitService
@@ -93,14 +93,14 @@ final class AddressServiceDefault implements AddressService {
     }
 
     public Observable<Void> deleteAddress(Long addressId) {
+        if (addressId == null) {
+            throw new NullPointerException("addressId cannot be null");
+        }
+
         CustomerToken customerToken = customerService.getCustomerToken();
 
         if (customerToken == null) {
-            throw new IllegalStateException("customer must be logged in");
-        }
-
-        if (addressId == null) {
-            throw new NullPointerException("addressId cannot be null");
+            return Observable.error(new BuyClientError(new IllegalStateException("customer must be logged in")));
         }
 
         int[] successCodes = {HTTP_NO_CONTENT};
@@ -125,7 +125,7 @@ final class AddressServiceDefault implements AddressService {
     @Override
     public Observable<List<Address>> getAddresses() {
         if (customerService.getCustomerToken() == null) {
-            throw new IllegalStateException("customer must be logged in");
+            return Observable.error(new BuyClientError(new IllegalStateException("customer must be logged in")));
         }
 
         return retrofitService
@@ -144,14 +144,14 @@ final class AddressServiceDefault implements AddressService {
 
     @Override
     public Observable<Address> getAddress(final Long addressId) {
+        if (addressId == null) {
+            throw new NullPointerException("addressId cannot be null");
+        }
+
         CustomerToken customerToken = customerService.getCustomerToken();
 
         if (customerToken == null) {
-            throw new IllegalStateException("customer must be logged in");
-        }
-
-        if (addressId == null) {
-            throw new NullPointerException("addressId cannot be null");
+            return Observable.error(new BuyClientError(new IllegalStateException("customer must be logged in")));
         }
 
         return retrofitService
@@ -170,14 +170,14 @@ final class AddressServiceDefault implements AddressService {
 
     @Override
     public Observable<Address> updateAddress(final Address address) {
+        if (address == null) {
+            throw new NullPointerException("address cannot be null");
+        }
+
         CustomerToken customerToken = customerService.getCustomerToken();
 
         if (customerToken == null) {
-            throw new IllegalStateException("customer must be logged in");
-        }
-
-        if (address == null) {
-            throw new NullPointerException("address cannot be null");
+            return Observable.error(new BuyClientError(new IllegalStateException("customer must be logged in")));
         }
 
         return retrofitService

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/CustomerServiceDefault.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/CustomerServiceDefault.java
@@ -75,7 +75,7 @@ final class CustomerServiceDefault implements CustomerService {
     }
 
     @Override
-    public void setCustomerToken(CustomerToken customerToken) {
+    public void setCustomerToken(final CustomerToken customerToken) {
         customerTokenRef.set(customerToken);
     }
 
@@ -207,7 +207,7 @@ final class CustomerServiceDefault implements CustomerService {
         CustomerToken customerToken = getCustomerToken();
 
         if (customerToken == null) {
-            throw new IllegalStateException("customer must be logged in");
+            return Observable.error(new BuyClientError(new IllegalStateException("customer must be logged in")));
         }
 
         return retrofitService
@@ -244,7 +244,7 @@ final class CustomerServiceDefault implements CustomerService {
         CustomerToken customerToken = getCustomerToken();
 
         if (customerToken == null) {
-            throw new IllegalStateException("customer must be logged in");
+            return Observable.error(new BuyClientError(new IllegalStateException("customer must be logged in")));
         }
 
         return retrofitService
@@ -265,7 +265,7 @@ final class CustomerServiceDefault implements CustomerService {
         CustomerToken customerToken = getCustomerToken();
 
         if (customerToken == null) {
-            throw new IllegalStateException("customer must be logged in");
+            return Observable.error(new BuyClientError(new IllegalStateException("customer must be logged in")));
         }
 
         return retrofitService
@@ -287,7 +287,7 @@ final class CustomerServiceDefault implements CustomerService {
         CustomerToken customerToken = getCustomerToken();
 
         if (customerToken == null) {
-            throw new IllegalStateException("customer must be logged in");
+            return Observable.error(new BuyClientError(new IllegalStateException("customer must be logged in")));
         }
 
         return retrofitService

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/OrderServiceDefault.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/OrderServiceDefault.java
@@ -69,7 +69,7 @@ final class OrderServiceDefault implements OrderService {
         CustomerToken customerToken = customerService.getCustomerToken();
 
         if (customerToken == null) {
-            throw new IllegalStateException("customer must be logged in");
+            return Observable.error(new BuyClientError(new IllegalStateException("customer must be logged in")));
         }
 
         return retrofitService
@@ -95,7 +95,7 @@ final class OrderServiceDefault implements OrderService {
         CustomerToken customerToken = customerService.getCustomerToken();
 
         if (customerToken == null) {
-            throw new IllegalStateException("customer must be logged in");
+            return Observable.error(new BuyClientError(new IllegalStateException("customer must be logged in")));
         }
 
         return retrofitService


### PR DESCRIPTION
# What this does
* changes the Customer, Address, Orders apis to return a BuyError instead of throwing an exception if the CustomerToken is not set.
* changes the order of the parameter testing to check the params that throw an exception before checking the token

closes #236 

@sav007 @bgulanowski please review