### PR TITLE
allow null PaymentToken when completing a checkout

### DIFF
--- a/MobileBuy/buy/src/androidTest/assets/test_shop_data.json
+++ b/MobileBuy/buy/src/androidTest/assets/test_shop_data.json
@@ -2,7 +2,8 @@
   "application_name": "MobileBuyTest",
   "product_ids": [
     "2096063363",
-    "2576257283"
+    "2576257283",
+    "8610580812"
   ],
   "collection_id": "109931075",
   "collection_id_without_tags": "2096063363",

--- a/MobileBuy/buy/src/androidTest/java/com/shopify/buy/data/TestData.java
+++ b/MobileBuy/buy/src/androidTest/java/com/shopify/buy/data/TestData.java
@@ -52,6 +52,10 @@ public class TestData {
         return data.get("product_ids").getAsJsonArray().get(0).getAsLong();
     }
 
+    public Long getProductIdWithNoCost() {
+        return data.get("product_ids").getAsJsonArray().get(2).getAsLong();
+    }
+
     public Long getProductIdWithVariants() {
         return data.get("product_ids").getAsJsonArray().get(1).getAsLong();
     }

--- a/MobileBuy/buy/src/androidTest/java/com/shopify/buy/service/BuyTest.java
+++ b/MobileBuy/buy/src/androidTest/java/com/shopify/buy/service/BuyTest.java
@@ -47,7 +47,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
     public void testApplyingGiftCardToCheckout() throws InterruptedException {
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
         applyGiftCardToCheckout(data.getGiftCardCode(TestData.GiftCardType.VALID11), data.getGiftCardValue(TestData.GiftCardType.VALID11));
 
         updateCheckout();
@@ -56,7 +56,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
     public void testApplyingInvalidGiftCardToCheckout() throws InterruptedException {
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
         buyClient.applyGiftCard(data.getGiftCardCode(TestData.GiftCardType.INVALID), checkout, new Callback<Checkout>() {
             @Override
             public void success(Checkout checkout) {
@@ -72,7 +72,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
     public void testApplyingExpiredGiftCardToCheckout() throws InterruptedException {
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
 
         final CountDownLatch countDownLatch = new CountDownLatch(1);
 
@@ -94,14 +94,14 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
     public void testRemovingGiftCardFromCheckout() throws InterruptedException {
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
         applyGiftCardToCheckout(data.getGiftCardCode(TestData.GiftCardType.VALID11), data.getGiftCardValue(TestData.GiftCardType.VALID11));
         removeGiftCardFromCheckout(checkout.getGiftCards().get(0));
     }
 
     @Test
     public void testRemovingInvalidGiftCardFromCheckout() throws InterruptedException {
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
         GiftCardPrivateAPIs invalidGiftCard = new GiftCardPrivateAPIs(data.getGiftCardCode(TestData.GiftCardType.INVALID));
         invalidGiftCard.setId(data.getGiftCardId(TestData.GiftCardType.INVALID));
 
@@ -124,7 +124,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
     public void testRemovingExpiredGiftCardFromCheckout() throws InterruptedException {
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
         GiftCardPrivateAPIs expiredGiftCard = new GiftCardPrivateAPIs(data.getGiftCardCode(TestData.GiftCardType.EXPIRED));
         expiredGiftCard.setId(data.getGiftCardId(TestData.GiftCardType.EXPIRED));
 
@@ -148,7 +148,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
     public void testApplyingTwoGiftCardsToCheckout() throws InterruptedException {
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
         applyGiftCardToCheckout(data.getGiftCardCode(TestData.GiftCardType.VALID11), data.getGiftCardValue(TestData.GiftCardType.VALID11));
         applyGiftCardToCheckout(data.getGiftCardCode(TestData.GiftCardType.VALID25), data.getGiftCardValue(TestData.GiftCardType.VALID25));
         assertEquals(checkout.getGiftCards().size(), 2);
@@ -156,7 +156,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
     public void testApplyingThreeGiftCardsToCheckout() throws InterruptedException {
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
         applyGiftCardToCheckout(data.getGiftCardCode(TestData.GiftCardType.VALID11), data.getGiftCardValue(TestData.GiftCardType.VALID11));
         applyGiftCardToCheckout(data.getGiftCardCode(TestData.GiftCardType.VALID25), data.getGiftCardValue(TestData.GiftCardType.VALID25));
         applyGiftCardToCheckout(data.getGiftCardCode(TestData.GiftCardType.VALID50), data.getGiftCardValue(TestData.GiftCardType.VALID50));
@@ -275,7 +275,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
     public void testFetchingShippingRatesWithInvalidCheckout() throws InterruptedException {
-        CheckoutPrivateAPIs privateCheckout = new CheckoutPrivateAPIs(createCart());
+        CheckoutPrivateAPIs privateCheckout = new CheckoutPrivateAPIs(createCart(data.getProductId()));
         privateCheckout.setToken("bananaaaa");
         checkout = privateCheckout;
         fetchShippingRates(HttpStatus.SC_NOT_FOUND);
@@ -309,7 +309,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
     public void testCheckoutFlowUsingCreditCard() throws InterruptedException {
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
         fetchShippingRates(HttpStatus.SC_OK);
         setShippingRate();
         addCreditCardToCheckout();
@@ -320,8 +320,26 @@ public class BuyTest extends ShopifyAndroidTestCase {
     }
 
     @Test
+    public void testCheckoutFlowMissingPaymentToken() throws InterruptedException {
+        createValidCheckout(data.getProductId());
+        fetchShippingRates(HttpStatus.SC_OK);
+        setShippingRate();
+
+        completeCheckout(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    public void testCheckoutFlowNoPaymentRequired() throws InterruptedException {
+        createValidCheckout(data.getProductIdWithNoCost());
+
+        completeCheckout();
+        getCheckoutCompletionStatus();
+        getCheckout();
+    }
+
+    @Test
     public void testChangedShippingAddress() throws InterruptedException {
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
         fetchShippingRates(HttpStatus.SC_OK);
         setShippingRate();
 
@@ -341,7 +359,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
     public void testCreateCheckoutWithValidDiscount() throws InterruptedException {
         final String discountCode = data.getDiscountCode(TestData.DiscountType.VALID);
 
-        Checkout checkout = new Checkout(createCart());
+        Checkout checkout = new Checkout(createCart(data.getProductId()));
         checkout.setShippingAddress(getShippingAddress());
         checkout.setBillingAddress(checkout.getShippingAddress());
         checkout.setDiscountCode(discountCode);
@@ -371,7 +389,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
 	public void testCreateCheckoutWithExpiredDiscount() throws InterruptedException {
-        Checkout checkout = new Checkout(createCart());
+        Checkout checkout = new Checkout(createCart(data.getProductId()));
         checkout.setShippingAddress(getShippingAddress());
         checkout.setBillingAddress(checkout.getShippingAddress());
         checkout.setDiscountCode(data.getDiscountCode(TestData.DiscountType.EXPIRED));
@@ -396,7 +414,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
     public void testCreateCheckoutWithNonExistentDiscount() throws InterruptedException {
-        Checkout checkout = new Checkout(createCart());
+        Checkout checkout = new Checkout(createCart(data.getProductId()));
         checkout.setShippingAddress(getShippingAddress());
         checkout.setBillingAddress(checkout.getShippingAddress());
         checkout.setDiscountCode("notarealdiscountasdasfsafasda");
@@ -423,7 +441,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
     public void testUpdateCheckoutWithValidDiscount() throws InterruptedException {
         final String discountCode = data.getDiscountCode(TestData.DiscountType.VALID);
 
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
         final float initialPaymentDue = Float.valueOf(checkout.getPaymentDue());
         checkout.setDiscountCode(discountCode);
 
@@ -484,7 +502,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
     public void testUpdatingCheckoutShippingAddress() throws InterruptedException {
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
 
         final Address shippingAddress = getShippingAddress();
 
@@ -520,7 +538,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
     public void testUpdatingCheckoutBillingAddress() throws InterruptedException {
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
 
         final Address billingAddress = getShippingAddress();
 
@@ -557,7 +575,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
     public void testUpdatingShippingRate() throws InterruptedException {
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
         fetchShippingRates(HttpStatus.SC_OK);
 
         assertEquals(null, checkout.getShippingRate());
@@ -587,7 +605,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
     @Test
     public void testExpiringCheckout() throws InterruptedException {
-        createValidCheckout();
+        createValidCheckout(data.getProductId());
 
         assertEquals(checkout.getReservationTime().longValue(), 300);
 
@@ -624,12 +642,12 @@ public class BuyTest extends ShopifyAndroidTestCase {
      * *****************************
      */
 
-    private Cart createCart() throws InterruptedException {
+    private Cart createCart(Long productId) throws InterruptedException {
         final AtomicReference<Product> productRef = new AtomicReference<>();
 
         final CountDownLatch latch = new CountDownLatch(1);
 
-        buyClient.getProduct(data.getProductId(), new Callback<Product>() {
+        buyClient.getProduct(productId, new Callback<Product>() {
             @Override
             public void success(Product product) {
                 productRef.set(product);
@@ -679,8 +697,8 @@ public class BuyTest extends ShopifyAndroidTestCase {
         return productRef.get().getVariants().get(0).getId();
     }
 
-    private void createValidCheckout() throws InterruptedException {
-        Checkout checkout = new Checkout(createCart());
+    private void createValidCheckout(Long productId) throws InterruptedException {
+        Checkout checkout = new Checkout(createCart(productId));
         checkout.setShippingAddress(getShippingAddress());
         checkout.setBillingAddress(checkout.getShippingAddress());
         checkout.setEmail("test@test.com");
@@ -705,7 +723,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
     }
 
     private void createCheckoutWithNoShippingAddress() throws InterruptedException {
-        Checkout checkout = new Checkout(createCart());
+        Checkout checkout = new Checkout(createCart(data.getProductId()));
         checkout.setBillingAddress(checkout.getShippingAddress());
 
         final CountDownLatch latch = new CountDownLatch(1);
@@ -929,26 +947,40 @@ public class BuyTest extends ShopifyAndroidTestCase {
     }
 
     private void completeCheckout() throws InterruptedException {
+        completeCheckout(HttpStatus.SC_OK);
+    }
+
+    private void completeCheckout(final int expectedResponse) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
 
         buyClient.completeCheckout(paymentToken, checkout.getToken(), new Callback<Checkout>() {
             @Override
             public void success(Checkout checkout) {
-                assertNotNull(checkout);
-                assertNotNull(checkout.getOrder());
-                assertNotNull(checkout.getOrder().getId());
-                BuyTest.this.checkout = checkout;
+                if (expectedResponse == HttpStatus.SC_OK) {
+                    assertNotNull(checkout);
+                    assertNotNull(checkout.getOrder());
+                    assertNotNull(checkout.getOrder().getId());
+                    BuyTest.this.checkout = checkout;
+                } else {
+                    fail("Checkout completed successfully but error was expected:" + expectedResponse);
+                }
                 latch.countDown();
             }
 
             @Override
             public void failure(BuyClientError error) {
-                fail(error.getRetrofitErrorBody());
+                if (expectedResponse != HttpStatus.SC_OK) {
+                    assertEquals(error.getRetrofitResponse().code(), expectedResponse);
+                } else {
+                    fail(error.getRetrofitErrorBody());
+                }
+                latch.countDown();
             }
         });
 
         latch.await();
     }
+
 
     private void getCheckout() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);

--- a/MobileBuy/buy/src/androidTest/java/com/shopify/buy/service/IllegalArgumentTest.java
+++ b/MobileBuy/buy/src/androidTest/java/com/shopify/buy/service/IllegalArgumentTest.java
@@ -211,13 +211,6 @@ public class IllegalArgumentTest extends ShopifyAndroidTestCase {
         checkException(NullPointerException.class, new Runnable() {
             @Override
             public void run() {
-                buyClient.completeCheckout(null, "test");
-            }
-        });
-
-        checkException(NullPointerException.class, new Runnable() {
-            @Override
-            public void run() {
                 buyClient.completeCheckout(PaymentToken.createCreditCardPaymentToken("test"), null);
             }
         });
@@ -226,13 +219,6 @@ public class IllegalArgumentTest extends ShopifyAndroidTestCase {
             @Override
             public void run() {
                 buyClient.completeCheckout(PaymentToken.createCreditCardPaymentToken("test"), "");
-            }
-        });
-
-        checkException(NullPointerException.class, new Runnable() {
-            @Override
-            public void run() {
-                buyClient.completeCheckout(null, "test");
             }
         });
 

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/CheckoutService.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/CheckoutService.java
@@ -97,7 +97,7 @@ public interface CheckoutService {
     /**
      * Complete the checkout and process the payment session
      *
-     * @param paymentToken  a {@link PaymentToken} associated with the checkout to be completed, not null if {@link Checkout#getPaymentDue()} is > 0
+     * @param paymentToken  a {@link PaymentToken} associated with the checkout to be completed, not null if {@link Checkout#getPaymentDue()} is greater than 0
      * @param checkoutToken checkout token associated with the specified payment token, not null or empty
      * @param callback the {@link Callback} that will be used to indicate the response from the asynchronous network operation, not null
      * @return cancelable task
@@ -107,7 +107,7 @@ public interface CheckoutService {
     /**
      * Complete the checkout and process the payment session
      *
-     * @param paymentToken a {@link PaymentToken} associated with the checkout to be completed, not null if {@link Checkout#getPaymentDue()} is > 0
+     * @param paymentToken a {@link PaymentToken} associated with the checkout to be completed, not null if {@link Checkout#getPaymentDue()} is greater than 0
      * @param checkoutToken checkout token associated with the specified payment token, not null or empty
      * @return cold observable that emits completed checkout
      */

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/CheckoutService.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/CheckoutService.java
@@ -97,7 +97,7 @@ public interface CheckoutService {
     /**
      * Complete the checkout and process the payment session
      *
-     * @param paymentToken  a {@link PaymentToken} associated with the checkout to be completed, not null
+     * @param paymentToken  a {@link PaymentToken} associated with the checkout to be completed, not null if {@link Checkout#getPaymentDue()} is > 0
      * @param checkoutToken checkout token associated with the specified payment token, not null or empty
      * @param callback the {@link Callback} that will be used to indicate the response from the asynchronous network operation, not null
      * @return cancelable task
@@ -107,7 +107,7 @@ public interface CheckoutService {
     /**
      * Complete the checkout and process the payment session
      *
-     * @param paymentToken a {@link PaymentToken} associated with the checkout to be completed, not null
+     * @param paymentToken a {@link PaymentToken} associated with the checkout to be completed, not null if {@link Checkout#getPaymentDue()} is > 0
      * @param checkoutToken checkout token associated with the specified payment token, not null or empty
      * @return cold observable that emits completed checkout
      */

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/CheckoutServiceDefault.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/dataprovider/CheckoutServiceDefault.java
@@ -214,9 +214,6 @@ final class CheckoutServiceDefault implements CheckoutService {
 
     @Override
     public Observable<Checkout> completeCheckout(final PaymentToken paymentToken, final String checkoutToken) {
-        if (paymentToken == null) {
-            throw new NullPointerException("paymentToken cannot be null");
-        }
         if (checkoutToken == null) {
             throw new NullPointerException("checkoutToken cannot be null");
         }
@@ -224,8 +221,10 @@ final class CheckoutServiceDefault implements CheckoutService {
             throw new IllegalArgumentException("checkout token cannot be empty");
         }
 
+        final PaymentToken paymentTokenToSend = paymentToken != null ? paymentToken : PaymentToken.createEmptyPaymentToken();
+
         return retrofitService
-            .completeCheckout(paymentToken, checkoutToken)
+            .completeCheckout(paymentTokenToSend, checkoutToken)
             .doOnNext(new RetrofitSuccessHttpStatusCodeHandler<Response<Void>>())
             .flatMap(new Func1<Response<Void>, Observable<Checkout>>() {
                 @Override

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/PaymentToken.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/PaymentToken.java
@@ -30,12 +30,31 @@ import com.google.gson.annotations.SerializedName;
  */
 public final class PaymentToken {
 
+    /**
+     * Creates a {@code PaymentToken} for use in completing credit card transaction
+     * @param paymentSessionId The payment session id
+     * @return a {@code PaymentToken}
+     */
     public static PaymentToken createCreditCardPaymentToken(String paymentSessionId) {
         return new PaymentToken(paymentSessionId);
     }
 
+    /**
+     * Creates a {@code PaymentToken} for use in completing an Android Pay transaction
+     * @param token The Android Pay token
+     * @param publicKeyHash The Android Pay public key
+     * @return an empty {@code PaymentToken}
+     */
     public static PaymentToken createAndroidPayPaymentToken(String token, String publicKeyHash) {
         return new PaymentToken(token, "android_pay", publicKeyHash);
+    }
+
+    /**
+     * Creates a {@code PaymentToken} with an empty body.  This token is only valid if the {@link Checkout#getPaymentDue()} is 0.
+     * @return an empty {@code PaymentToken}
+     */
+    public static PaymentToken createEmptyPaymentToken() {
+        return new PaymentToken(null, null, null);
     }
 
     @SerializedName("payment_session_id")
@@ -46,12 +65,12 @@ public final class PaymentToken {
 
     private PaymentToken(String paymentSessionId) {
         this.paymentSessionId = paymentSessionId;
-        this.wrapper = null;
+        wrapper = null;
     }
 
     private PaymentToken(String token, String type, String publicKeyHash) {
-        this.paymentSessionId = null;
-        this.wrapper = new Wrapper(token, type, publicKeyHash);
+        paymentSessionId = null;
+        wrapper = new Wrapper(token, type, publicKeyHash);
     }
 
     private static final class Wrapper {


### PR DESCRIPTION
* removes a null check on the PaymentToken, it is allowed to be null if no payment is required
* updates tests to check cases where the token is needed/not needed
* updates javadoc

resolves #288, resolves #291 


@sav007 @yervantk please review