### PR TITLE
properties must be a map<String, Object> the value is not always a String

### DIFF
--- a/MobileBuy/buy/src/androidTest/java/com/shopify/buy/service/BuyTest.java
+++ b/MobileBuy/buy/src/androidTest/java/com/shopify/buy/service/BuyTest.java
@@ -24,6 +24,7 @@ import org.apache.http.HttpStatus;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -649,9 +650,13 @@ public class BuyTest extends ShopifyAndroidTestCase {
 
         // add some custom properties
         LineItem lineItem = cart.getLineItems().get(0);
-        Map<String, String> properties = lineItem.getProperties();
+        Map<String, Object> properties = lineItem.getProperties();
         properties.put("color", "red");
         properties.put("size", "large");
+
+        // Add a couple non-primitive properties
+        properties.put("materials", Collections.singletonList("hello"));
+        properties.put("foo", PaymentToken.createCreditCardPaymentToken("bar"));
 
         return cart;
     }
@@ -731,7 +736,7 @@ public class BuyTest extends ShopifyAndroidTestCase {
         assertNotNull(checkout.getLineItems());
         assertEquals(1, checkout.getLineItems().size());
         assertNotNull(checkout.getLineItems().get(0).getProperties());
-        assertEquals(2, checkout.getLineItems().get(0).getProperties().size());
+        assertEquals(4, checkout.getLineItems().get(0).getProperties().size());
         assertEquals(checkout.getSourceName(), "mobile_app");
     }
 

--- a/MobileBuy/buy/src/main/java/com/shopify/buy/model/LineItem.java
+++ b/MobileBuy/buy/src/main/java/com/shopify/buy/model/LineItem.java
@@ -71,7 +71,7 @@ public class LineItem {
     @SerializedName("fulfillment_service")
     protected String fulfillmentService;
 
-    protected Map<String, String> properties;
+    protected Map<String, Object> properties;
 
     @SerializedName("total_discount")
     protected String totalDiscount;
@@ -153,7 +153,7 @@ public class LineItem {
     /**
      * @return Custom properties set on this line item.
      */
-    public Map<String, String> getProperties() {
+    public Map<String, Object> getProperties() {
         if (properties == null) {
             properties = new HashMap<>();
         }


### PR DESCRIPTION
Fixes issues with LineItem properties that are not map<String, String> crash GSON parser.
After checking with the server team, the key will be a String, but the value may be any arbitray json object.

fixes #293 

@sav007 @yervantk please review.


