### PR TITLE
Remove manifest things

### DIFF
--- a/MobileBuy/buy3-pay-support/src/main/AndroidManifest.xml
+++ b/MobileBuy/buy3-pay-support/src/main/AndroidManifest.xml
@@ -1,8 +1,3 @@
-<manifest package="com.shopify.buy3.pay"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest package="com.shopify.buy3.pay">
 
-    <application
-        android:allowBackup="false"
-        android:label="@string/app_name"
-        android:supportsRtl="true" />
 </manifest>

--- a/MobileBuy/buy3-pay-support/src/main/res/values/strings.xml
+++ b/MobileBuy/buy3-pay-support/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">android-pay</string>
-</resources>


### PR DESCRIPTION
This removes things from the manifest that are not needed and can cause conflicts with apps that would use the `buy3-pay-support` library