### PR TITLE
Update mobile buy setup steps

### DIFF
--- a/MobileBuy/sample/README.md
+++ b/MobileBuy/sample/README.md
@@ -8,12 +8,11 @@ The Mobile Buy SDK ships with a sample application that demonstrates how to buil
 
 To run the sample application, you need to provide credentials to the shop that the app will point to:
 
-1. Make sure that you have the **Mobile App** channel installed in your Shopify admin.
-2. From your Shopify admin, navigate to the **Mobile App** channel, and then copy your API key.
-3. Open the Sample Application project in `/MobileBuy/sample`
-4. Run `git submodule update --init --recursive` to update recursevly git submodules
-5. Sample application provides 2 product flavours: `shopify` and `apollo`. You should select `shopify` in AS to switch sample application to use BuySDK. At the same time `apollo` flavour demonstrates how you can use Apollo GraphQL client with Shopify StoreFront schema. (NOTE: please make sure you clean the project after you switching between these 2 flavours)
-6. Create `shop.properties` file under the root folder and add next lines:
+1. Create a private app with a Storefront API access token to access the storefront data. The storefront access token acts as the API key.
+2. Open the Sample Application project in `/MobileBuy/sample`
+3. Run `git submodule update --init --recursive` to update recursively git submodules
+4. Sample application provides two product flavors: `shopify` and `apollo`. You should select `shopify` in AS to switch sample application to use BuySDK. At the same time `apollo` flavor demonstrates how you can use Apollo GraphQL client with Shopify StoreFront schema (NOTE: please make sure you clean the project after you switching between these two flavors).
+5. Create `shop.properties` file under the root folder and add next lines:
 
 ```
 SHOP_DOMAIN=<your-shop-here>.myshopify.com


### PR DESCRIPTION
This PR updates a few steps in the setup to account for the deprecated mobile app channel. See linked issue for context.

issue:

https://github.com/Shopify/help/issues/11283