### PR TITLE
Automate SDK and client generation

### DIFF
--- a/MobileBuy/buy3/src/main/java/com/shopify/buy3/GraphClient.kt
+++ b/MobileBuy/buy3/src/main/java/com/shopify/buy3/GraphClient.kt
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit
 
 private val DEFAULT_HTTP_CONNECTION_TIME_OUT_MS = TimeUnit.SECONDS.toMillis(10)
 private val DEFAULT_HTTP_READ_WRITE_TIME_OUT_MS = TimeUnit.SECONDS.toMillis(20)
-private val STOREFRONT_API_VERSION = "2020-01"
+private const val STOREFRONT_API_VERSION = Storefront.API_VERSION
 
 @DslMarker
 annotation class GraphClientBuilder

--- a/MobileBuy/buy3/src/main/java/com/shopify/buy3/GraphClient.kt
+++ b/MobileBuy/buy3/src/main/java/com/shopify/buy3/GraphClient.kt
@@ -42,7 +42,6 @@ import java.util.concurrent.TimeUnit
 
 private val DEFAULT_HTTP_CONNECTION_TIME_OUT_MS = TimeUnit.SECONDS.toMillis(10)
 private val DEFAULT_HTTP_READ_WRITE_TIME_OUT_MS = TimeUnit.SECONDS.toMillis(20)
-private const val STOREFRONT_API_VERSION = Storefront.API_VERSION
 
 @DslMarker
 annotation class GraphClientBuilder
@@ -159,7 +158,7 @@ class GraphClient private constructor(
         @VisibleForTesting
         internal var dispatcher: ScheduledThreadPoolExecutor? = null
         @VisibleForTesting
-        internal var endpointUrl = HttpUrl.parse("https://$shopDomain/api/$STOREFRONT_API_VERSION/graphql")
+        internal var endpointUrl = HttpUrl.parse("https://$shopDomain/api/${Storefront.API_VERSION}/graphql")
 
         init {
             shopDomain.checkNotBlank("shopDomain can't be empty")

--- a/MobileBuy/buy3/src/main/java/com/shopify/buy3/Storefront.java
+++ b/MobileBuy/buy3/src/main/java/com/shopify/buy3/Storefront.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 
 public class Storefront {
+    public static final String API_VERSION = "2020-01";
+
     public static QueryRootQuery query(QueryRootQueryDefinition queryDef) {
         StringBuilder queryString = new StringBuilder("{");
         QueryRootQuery query = new QueryRootQuery(queryString);
@@ -1727,7 +1729,7 @@ public class Storefront {
     }
 
     /**
-    * The set of valid sort keys for the articles query.
+    * The set of valid sort keys for the Article query.
     */
     public enum ArticleSortKeys {
         /**
@@ -2932,7 +2934,7 @@ public class Storefront {
     }
 
     /**
-    * The set of valid sort keys for the blogs query.
+    * The set of valid sort keys for the Blog query.
     */
     public enum BlogSortKeys {
         /**
@@ -11834,7 +11836,7 @@ public class Storefront {
     }
 
     /**
-    * The set of valid sort keys for the collections query.
+    * The set of valid sort keys for the Collection query.
     */
     public enum CollectionSortKeys {
         /**
@@ -16174,27 +16176,27 @@ public class Storefront {
     */
     public enum CropRegion {
         /**
-        * Keep the bottom of the image
+        * Keep the bottom of the image.
         */
         BOTTOM,
 
         /**
-        * Keep the center of the image
+        * Keep the center of the image.
         */
         CENTER,
 
         /**
-        * Keep the left of the image
+        * Keep the left of the image.
         */
         LEFT,
 
         /**
-        * Keep the right of the image
+        * Keep the right of the image.
         */
         RIGHT,
 
         /**
-        * Keep the top of the image
+        * Keep the top of the image.
         */
         TOP,
 
@@ -25257,10 +25259,19 @@ public class Storefront {
     * List of supported image content types.
     */
     public enum ImageContentType {
+        /**
+        * A JPG image.
+        */
         JPG,
 
+        /**
+        * A PNG image.
+        */
         PNG,
 
+        /**
+        * A WEBP image.
+        */
         WEBP,
 
         UNKNOWN_VALUE;
@@ -29265,7 +29276,10 @@ public class Storefront {
 
                 /**
                 * Completes a checkout with a tokenized payment.
+                *
+                * @deprecated Use `checkoutCompleteWithTokenizedPaymentV3` instead
                 */
+                @Deprecated
                 public MutationQuery checkoutCompleteWithTokenizedPaymentV2(ID checkoutId, TokenizedPaymentInputV2 payment, CheckoutCompleteWithTokenizedPaymentV2PayloadQueryDefinition queryDef) {
                     startField("checkoutCompleteWithTokenizedPaymentV2");
 
@@ -30627,6 +30641,8 @@ public class Storefront {
 
                 /**
                 * Completes a checkout with a tokenized payment.
+                *
+                * @deprecated Use `checkoutCompleteWithTokenizedPaymentV3` instead
                 */
 
                 public CheckoutCompleteWithTokenizedPaymentV2Payload getCheckoutCompleteWithTokenizedPaymentV2() {
@@ -33283,7 +33299,7 @@ public class Storefront {
             }
 
             /**
-            * The set of valid sort keys for the orders query.
+            * The set of valid sort keys for the Order query.
             */
             public enum OrderSortKeys {
                 /**
@@ -33972,7 +33988,7 @@ public class Storefront {
             }
 
             /**
-            * The set of valid sort keys for the pages query.
+            * The set of valid sort keys for the Page query.
             */
             public enum PageSortKeys {
                 /**
@@ -36404,7 +36420,7 @@ public class Storefront {
             }
 
             /**
-            * The set of valid sort keys for the products query.
+            * The set of valid sort keys for the ProductCollection query.
             */
             public enum ProductCollectionSortKeys {
                 /**
@@ -36756,7 +36772,7 @@ public class Storefront {
             }
 
             /**
-            * The set of valid sort keys for the images query.
+            * The set of valid sort keys for the ProductImage query.
             */
             public enum ProductImageSortKeys {
                 /**
@@ -37312,7 +37328,7 @@ public class Storefront {
             }
 
             /**
-            * The set of valid sort keys for the products query.
+            * The set of valid sort keys for the Product query.
             */
             public enum ProductSortKeys {
                 /**
@@ -39162,7 +39178,7 @@ public class Storefront {
             }
 
             /**
-            * The set of valid sort keys for the variants query.
+            * The set of valid sort keys for the ProductVariant query.
             */
             public enum ProductVariantSortKeys {
                 /**

--- a/MobileBuy/buy3/src/test/java/com/shopify/buy3/GraphClientBuilderTest.kt
+++ b/MobileBuy/buy3/src/test/java/com/shopify/buy3/GraphClientBuilderTest.kt
@@ -40,7 +40,7 @@ import java.io.File
 private const val PACKAGE_NAME = "com.shopify.buy3.test"
 private const val SHOP_DOMAIN = "shopDomain"
 private const val ACCESS_TOKEN = "access_token"
-private const val STOREFRONT_API_VERSION = "2020-01"
+private const val STOREFRONT_API_VERSION = Storefront.API_VERSION
 private val ENDPOINT_URL = HttpUrl.parse(String.format("https://%s/api/%s/graphql", SHOP_DOMAIN, STOREFRONT_API_VERSION))
 
 @RunWith(MockitoJUnitRunner::class)

--- a/MobileBuy/buy3/src/test/java/com/shopify/buy3/GraphClientBuilderTest.kt
+++ b/MobileBuy/buy3/src/test/java/com/shopify/buy3/GraphClientBuilderTest.kt
@@ -40,8 +40,7 @@ import java.io.File
 private const val PACKAGE_NAME = "com.shopify.buy3.test"
 private const val SHOP_DOMAIN = "shopDomain"
 private const val ACCESS_TOKEN = "access_token"
-private const val STOREFRONT_API_VERSION = Storefront.API_VERSION
-private val ENDPOINT_URL = HttpUrl.parse(String.format("https://%s/api/%s/graphql", SHOP_DOMAIN, STOREFRONT_API_VERSION))
+private val ENDPOINT_URL = HttpUrl.parse(String.format("https://%s/api/%s/graphql", SHOP_DOMAIN, Storefront.API_VERSION))
 
 @RunWith(MockitoJUnitRunner::class)
 class GraphClientBuilderTest {

--- a/MobileBuy/buy3/update_schema.rb
+++ b/MobileBuy/buy3/update_schema.rb
@@ -16,9 +16,17 @@ OptionParser.new do |opts|
 end.parse!
 
 shared_storefront_api_key = "4a6c829ec3cb12ef9004bf8ed27adf12"
-storefront_api_version = '2020-01'
-endpoint = URI("https://app.shopify.com/services/graphql/introspection/storefront?api_client_api_key=#{shared_storefront_api_key}&api_version=#{storefront_api_version}")
-body = Net::HTTP.get(endpoint)
+storefront_api_version = ARGV[0]
+
+abort("Error: API Version not specified") if storefront_api_version.nil? or storefront_api_version.empty?
+
+url = "https://app.shopify.com/services/graphql/introspection/storefront?api_client_api_key=#{shared_storefront_api_key}&api_version=#{storefront_api_version}"
+uri = URI(url)
+
+response = Net::HTTP.get_response(uri)
+abort("Error fetching details for the api version #{storefront_api_version}") unless response.kind_of? Net::HTTPSuccess
+body = response.body
+
 schema = GraphQLSchema.new(JSON.parse(body))
 custom_scalars = [
   GraphQLJavaGen::Scalar.new(
@@ -40,5 +48,6 @@ GraphQLJavaGen.new(
   package_name: "com.shopify.buy3",
   nest_under: 'Storefront',
   custom_scalars: custom_scalars,
-  include_deprecated: true
+  include_deprecated: true,
+  version: storefront_api_version
 ).save(target_filename)

--- a/MobileBuy/buy3/update_schema.rb
+++ b/MobileBuy/buy3/update_schema.rb
@@ -20,14 +20,12 @@ storefront_api_version = ARGV[0]
 
 abort("Error: API Version not specified") if storefront_api_version.nil? or storefront_api_version.empty?
 
-url = "https://app.shopify.com/services/graphql/introspection/storefront?api_client_api_key=#{shared_storefront_api_key}&api_version=#{storefront_api_version}"
-uri = URI(url)
+uri = URI("https://app.shopify.com/services/graphql/introspection/storefront?api_client_api_key=#{shared_storefront_api_key}&api_version=#{storefront_api_version}")
 
 response = Net::HTTP.get_response(uri)
 abort("Error fetching details for the api version #{storefront_api_version}") unless response.kind_of? Net::HTTPSuccess
-body = response.body
 
-schema = GraphQLSchema.new(JSON.parse(body))
+schema = GraphQLSchema.new(JSON.parse(response.body))
 custom_scalars = [
   GraphQLJavaGen::Scalar.new(
     type_name: 'Money',


### PR DESCRIPTION
Make updating the API version on the SDK a lot easier.
We want to have a single source of truth for the current storefront API version that the SDK is currently using.This single source of truth is read by both the code generator and graphql client.

### Impact
* It becomes possible to automate upgrading of the sdk with the every new storefront API scheduled release.
* It becomes easier for users of the SDK to update the API version of their SDK.
