### PR TITLE
Add automation for updating the artifacts to Bintray

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Create SDK release
+
+on: 
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    
+    steps:
+    
+    - uses: actions/checkout@master
+      with:
+        ref: 'master'
+    
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6' 
+
+    - uses: actions/checkout@v1
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8    
+
+    - name: Create a draft release
+      uses: actions/github-script@0.9.0
+      with:
+        script: |
+          // Get the current date
+          const today = new Date();
+          const yyyy = today.getFullYear();
+          const mm = String(today.getMonth() + 1).padStart(2, '0');
+          const api_version = yyyy + '-' + mm
+          github.repos.createRelease({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            name: "ADD VERSION"
+            body: "Release notes:\n - https://shopify.dev/concepts/about-apis/versioning/release-notes/" + api_version,
+            tag_name: 'x.x.x',
+            target_commitish: 'master',
+            draft: true, # TODO this should be false in production
+            prerelease: false,
+          })
+          
+    - name: Push to cocoapods
+      working-directory: ./MobileBuy
+      env:
+        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+        BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
+      run: |
+        set -eo pipefail
+        echo "bintray.user=$BINTRAY_USER" >> local.properties
+        echo "bintray.apikey=$BINTRAY_KEY" >> local.properties
+        ./gradlew clean :buy3:bintrayUpload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,11 @@ jobs:
             body: "Release notes:\n - https://shopify.dev/concepts/about-apis/versioning/release-notes/" + api_version,
             tag_name: 'x.x.x',
             target_commitish: 'master',
-            draft: true, # TODO this should be false in production
+            draft: true
             prerelease: false,
           })
           
-    - name: Push to cocoapods
+    - name: Push to BinTray
       working-directory: ./MobileBuy
       env:
         BINTRAY_USER: ${{ secrets.BINTRAY_USER }}


### PR DESCRIPTION
### What this does?

This releases the SDK to the bintray repo when a PR is merged into master

Still need to update these token in the secrets:
`BINTRAY_USER`
`BINTRAY_KEY`