### PR TITLE
Update actions to use GITHUB_ENV file instead of set-env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       id: version
       run: |
         API_VERSION="$(date +'%Y-%m')"
-        echo "::set-env name=API_VERSION::$API_VERSION"
+        echo "API_VERSION=$API_VERSION" >> $GITHUB_ENV
 
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       id: version
       run: |
         API_VERSION="$(date +'%Y-%m')"
-        echo "::set-env name=API_VERSION::$API_VERSION"
+        echo "API_VERSION=$API_VERSION" >> $GITHUB_ENV
 
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6


### PR DESCRIPTION
set-env was deprecated at the end of last year

### What this does

Removes set-env.
