### PR TITLE
Support Query/Mutation Directives

### DIFF
--- a/MobileBuy/buy3/Gemfile.lock
+++ b/MobileBuy/buy3/Gemfile.lock
@@ -2,12 +2,12 @@ PATH
   remote: ../libs/graphql_java_gen
   specs:
     graphql_java_gen (0.2.0)
-      graphql_schema (~> 0.1.1)
+      graphql_schema (~> 0.1.8)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    graphql_schema (0.1.6)
+    graphql_schema (0.1.8)
 
 PLATFORMS
   ruby

--- a/MobileBuy/buy3/src/main/java/com/shopify/buy3/Storefront.java
+++ b/MobileBuy/buy3/src/main/java/com/shopify/buy3/Storefront.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.shopify.graphql.support.AbstractResponse;
 import com.shopify.graphql.support.Arguments;
+import com.shopify.graphql.support.Directive;
 import com.shopify.graphql.support.Error;
 import com.shopify.graphql.support.Query;
 import com.shopify.graphql.support.SchemaViolationError;
@@ -21,15 +22,21 @@ import java.math.BigDecimal;
 import org.joda.time.DateTime;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class Storefront {
     public static final String API_VERSION = "2021-04";
 
     public static QueryRootQuery query(QueryRootQueryDefinition queryDef) {
-        StringBuilder queryString = new StringBuilder("{");
+        return query(Collections.emptyList(), queryDef);
+    }
+
+    public static QueryRootQuery query(List<Directive> directives, QueryRootQueryDefinition queryDef) {
+        StringBuilder queryString = new StringBuilder("query");
+        for (Directive directive : directives) {
+            queryString.append(" " + directive.toString());
+        }
+        queryString.append(" {");
         QueryRootQuery query = new QueryRootQuery(queryString);
         queryDef.define(query);
         queryString.append('}');
@@ -69,7 +76,15 @@ public class Storefront {
     }
 
     public static MutationQuery mutation(MutationQueryDefinition queryDef) {
-        StringBuilder queryString = new StringBuilder("mutation{");
+        return mutation(Collections.emptyList(), queryDef);
+    }
+
+    public static MutationQuery mutation(List<Directive> directives, MutationQueryDefinition queryDef) {
+        StringBuilder queryString = new StringBuilder("mutation");
+        for (Directive directive : directives) {
+            queryString.append(" " + directive.toString());
+        }
+        queryString.append(" {");
         MutationQuery query = new MutationQuery(queryString);
         queryDef.define(query);
         queryString.append('}');

--- a/MobileBuy/buy3/src/test/java/com/shopify/buy3/GraphClientTest.kt
+++ b/MobileBuy/buy3/src/test/java/com/shopify/buy3/GraphClientTest.kt
@@ -78,7 +78,7 @@ class GraphClientTest {
             assertThat(headers["X-SDK-Version"]).isEqualTo(BuildConfig.BUY_SDK_VERSION)
             assertThat(headers["X-SDK-Variant"]).isEqualTo("android")
             assertThat(headers["X-Shopify-Storefront-Access-Token"]).isEqualTo("accessToken")
-            assertThat(this.body.readUtf8()).isEqualTo("{shop{name}}")
+            assertThat(this.body.readUtf8()).isEqualTo("query {shop{name}}")
         }
     }
 


### PR DESCRIPTION
Updates to the latest `graphql_java_gen` that supports `QUERY` and `MUTATION` directives.