### PR TITLE
Date parsing fix

### DIFF
--- a/MobileBuy/buy3/src/main/java/com/shopify/buy3/Utils.java
+++ b/MobileBuy/buy3/src/main/java/com/shopify/buy3/Utils.java
@@ -26,6 +26,7 @@ package com.shopify.buy3;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Locale;
 
@@ -33,11 +34,17 @@ final class Utils {
   private static final SimpleDateFormat DATE_TIME_FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
 
   static Date parseDateTime(String dateTime) {
-      try {
+    try {
+        Instant instant = Instant.parse(dateTime);
+        return Date.from(instant);
+    } catch(Exception e1) {
+        // Fallback to legacy parsing in case of exception
+        try {
           return DATE_TIME_FORMATTER.parse(dateTime);
-      } catch (ParseException e) {
+        } catch (ParseException e2) {
           return new Date();
-      }
+        }
+    }
   }
 
   private Utils() {


### PR DESCRIPTION
This PR improves the robustness of date parsing by introducing support for ISO 8601-compliant date strings (e.g., 2022-07-06T12:51:06Z) using `java.time.Instant`.

The `parseDateTime` method now attempts to parse using `Instant.parse()` first, and falls back to the existing `SimpleDateFormat` approach if that fails.

It should fix #773 