### PR TITLE
cache hardening

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
+        with:
+          cache-disabled: true
 
       - name: Publish Package
         working-directory: ./MobileBuy


### PR DESCRIPTION
Disables the Gradle cache on the publish workflow (`cache-disabled: true` on `gradle/actions/setup-gradle`) so the publish build does not restore a cache populated by other workflow runs.